### PR TITLE
Marlin/Configuration: Decrease the max hotend temp to 240C

### DIFF
--- a/Ender-3 Firmware (Marlin)/Ender-3 (includes power failure resume- English)/Marlin/Configuration.h
+++ b/Ender-3 Firmware (Marlin)/Ender-3 (includes power failure resume- English)/Marlin/Configuration.h
@@ -322,11 +322,11 @@
 // When temperature exceeds max temp, your heater will be switched off.
 // This feature exists to protect your hotend from overheating accidentally, but *NOT* from thermistor short/failure!
 // You should use MINTEMP for thermistor short/failure protection.
-#define HEATER_0_MAXTEMP 275
-#define HEATER_1_MAXTEMP 275
-#define HEATER_2_MAXTEMP 275
-#define HEATER_3_MAXTEMP 275
-#define HEATER_4_MAXTEMP 275
+#define HEATER_0_MAXTEMP 255
+#define HEATER_1_MAXTEMP 255
+#define HEATER_2_MAXTEMP 255
+#define HEATER_3_MAXTEMP 255
+#define HEATER_4_MAXTEMP 255
 #define BED_MAXTEMP 125
 
 //===========================================================================


### PR DESCRIPTION
On my stock Creality Ender-3 the PTFE bowen tube melts and starts to burn when it reaches 260 C that the printer allows out of the box, this commit attempts to decrease the max temperature by changing HEADER_X_MAXTEMP in Marlin to decrease the max safe temperature to 240 to avoid this fire hazard.

This issue can be reproduced by using 260C hotend temperature on the printer without the filament and the PTFE bowen tube should start to smoke and burn in <50 sec